### PR TITLE
Update Curl to 7.74.0-1.3+deb11u2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # renovate: datasource=github-tags depName=docker/cli extractVersion=^v(?<version>.*)$
 ENV DOCKERCLI_VERSION=20.10.17
 # renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION=7.74.0-1.3+deb11u1
+ENV CURL_VERSION=7.74.0-1.3+deb11u2
 # renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
 ENV CACERTIFICATES_VERSION=20210119
 # renovate: datasource=repology depName=debian_11/lsb-release versioning=loose


### PR DESCRIPTION
Update Curl to 7.74.0-1.3+deb11u2 to fix several security issues. 

See https://www.debian.org/security/2022/dsa-5197 for details