### PR TITLE
Fix .NET version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ The following example shows the container used for a deployment step which shows
 
 ### Tags
 
-| Tag        | Description                                                                                   | Base Image       | Docker CLI | .NET SDK  | Size                                                                                                                             |
-|------------|-----------------------------------------------------------------------------------------------|------------------|------------|-----------|----------------------------------------------------------------------------------------------------------------------------------|
-| latest     | Latest stable release (from `main` branch)                                                    | debian:11.3-slim | 20.10.17   | 6.0.301   | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/latest?style=flat-square)    |
-| unstable   | Latest unstable release (from `develop` branch)                                               | debian:11.3-slim | 20.10.17   | 6.0.301   | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/unstable?style=flat-square)  |
-| 6.0.301    | [.NET SDK 6.0.301](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.6/6.0.6.md) | debian:11.3-slim | 20.10.17   | 6.0.301   | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/6.0.301?style=flat-square)   |
-| 6.0.302    | [.NET SDK 6.0.302](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.7/6.0.7.md) | debian:11.3-slim | 20.10.17   | 6.0.302   | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/6.0.302?style=flat-square)   |
-| 6.0.302.1  | [.NET SDK 6.0.302](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.7/6.0.7.md) | debian:11.3-slim | 20.10.17   | 6.0.302.1 | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/6.0.302.1?style=flat-square) |
+| Tag        | Description                                                                                   | Base Image       | Docker CLI | .NET SDK | Size                                                                                                                             |
+|------------|-----------------------------------------------------------------------------------------------|------------------|------------|----------|----------------------------------------------------------------------------------------------------------------------------------|
+| latest     | Latest stable release (from `main` branch)                                                    | debian:11.3-slim | 20.10.17   | 6.0.301  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/latest?style=flat-square)    |
+| unstable   | Latest unstable release (from `develop` branch)                                               | debian:11.3-slim | 20.10.17   | 6.0.301  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/unstable?style=flat-square)  |
+| 6.0.301    | [.NET SDK 6.0.301](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.6/6.0.6.md) | debian:11.3-slim | 20.10.17   | 6.0.301  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/6.0.301?style=flat-square)   |
+| 6.0.302    | [.NET SDK 6.0.302](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.7/6.0.7.md) | debian:11.3-slim | 20.10.17   | 6.0.302  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/6.0.302?style=flat-square)   |
+| 6.0.302.1  | [.NET SDK 6.0.302](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.7/6.0.7.md) | debian:11.3-slim | 20.10.17   | 6.0.302  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/6.0.302.1?style=flat-square) |
 
 ### Configuration
 


### PR DESCRIPTION
6.0.302.1 was a patch release for fixing Curl CVEs and contains .NET 6.0.302