### PR TITLE
Don't ship build dependencies in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,48 @@
-FROM debian:11.6-slim
+# Base image containing dependencies used in builder and final image
+FROM debian:11.6-slim AS base
+
+# Make sure to fail due to an error at any stage in shell pipes
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+#Disabled renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
+ENV CACERTIFICATES_VERSION=20210119
+
+RUN apt-get update -y && \
+  # Install necessary dependencies
+  apt-get install -y --no-install-recommends ca-certificates=${CACERTIFICATES_VERSION} && \
+  # Clean up
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+
+# Builder image
+FROM base AS build
+
+# Make sure to fail due to an error at any stage in shell pipes
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+#Disabled renovate: datasource=repology depName=debian_11/curl versioning=loose
+ENV CURL_VERSION=7.74.0-1.3+deb11u5
+#Disabled renovate: datasource=repology depName=debian_11/lsb-release versioning=loose
+ENV LSBRELEASE_VERSION=11.1.0
+#Disabled renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
+ENV GNUPG_VERSION=2.2.27-2+deb11u2
+
+RUN apt-get update -y && \
+  # Install necessary dependencies
+  apt-get install -y --no-install-recommends curl=${CURL_VERSION} lsb-release=${LSBRELEASE_VERSION} gnupg=${GNUPG_VERSION} && \
+  # Add Dockers public key
+  mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+  # Add Dockers APT repository to the list of sources
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+  # Add .NET PPA
+  curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb && \
+  dpkg -i /tmp/packages-microsoft-prod.deb && \
+  rm -rf /tmp/*
+
+# Final image
+FROM base AS final
 
 LABEL org.opencontainers.image.vendor="Swiss GRC AG"
 LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"
@@ -8,26 +52,22 @@ LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+WORKDIR /
+# Copy Docker keyring
+COPY --from=build /etc/apt/keyrings/ /etc/apt/keyrings
+# Copy .NET keyring
+COPY --from=build /etc/apt/trusted.gpg.d/ /etc/apt/trusted.gpg.d
+COPY --from=build /etc/apt/sources.list.d/ /etc/apt/sources.list.d
+
 # Install Docker CLI
 
 # renovate: datasource=github-tags depName=docker/cli extractVersion=^v(?<version>.*)$
 ENV DOCKERCLI_VERSION=20.10.23
-#Disabled renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION=7.74.0-1.3+deb11u5
-#Disabled renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CACERTIFICATES_VERSION=20210119
-#Disabled renovate: datasource=repology depName=debian_11/lsb-release versioning=loose
-ENV LSBRELEASE_VERSION=11.1.0
-#Disabled renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG_VERSION=2.2.27-2+deb11u2
 
 RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends ca-certificates=${CACERTIFICATES_VERSION} curl=${CURL_VERSION} lsb-release=${LSBRELEASE_VERSION} gnupg=${GNUPG_VERSION} && \
-  mkdir -p /etc/apt/keyrings && \
-  curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-  apt-get update -y && \
+  # Install Docker CLI
   apt-get install -y --no-install-recommends docker-ce-cli=5:${DOCKERCLI_VERSION}~3-0~debian-bullseye && \
+  # Clean up
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   # Smoke test
@@ -49,10 +89,10 @@ ENV \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-RUN curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb && \
-  dpkg -i /tmp/packages-microsoft-prod.deb && \
-  rm -rf /tmp/* && \
-  apt-get update && apt-get install -y --no-install-recommends dotnet-sdk-6.0=${DOTNET_VERSION}-1 && \
+RUN apt-get update -y && \
+  # Install .NET 6
+  apt-get install -y --no-install-recommends dotnet-sdk-6.0=${DOTNET_VERSION}-1 && \
+  # Clean up
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   # Smoke test

--- a/README.md
+++ b/README.md
@@ -47,17 +47,4 @@ The following example shows the container used for a deployment step which shows
 | 6.0.404    | [.NET SDK 6.0.404](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.12/6.0.12.md) | debian:11.5-slim | 20.10.21   | 6.0.404  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/6.0.404?style=flat-square)   |
 | 6.0.405    | [.NET SDK 6.0.405](https://github.com/dotnet/core/blob/main/release-notes/6.0/6.0.13/6.0.13.md) | debian:11.6-slim | 20.10.22   | 6.0.405  | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-dotnet/6.0.405?style=flat-square)   |
 
-### Configuration
-
-These environment variables are supported:
-
-| Environment variable   | Default value        | Description                                                      |
-|------------------------|----------------------|------------------------------------------------------------------|
-| DOCKERCLI_VERSION      | `20.10.22`           | Version of Docker CLI installed in the image.                    |
-| DOTNET_VERSION         | `6.0.405`            | Version of .NET installed in the image.                          |
-| CACERTIFICATES_VERSION | `20210119`           | Version of `ca-certificates` package used to install components. |
-| CURL_VERSION           | `7.74.0-1.3+deb11u5` | Version of `curl` package used to install components.            |
-| LSBRELEASE_VERSION     | `11.1.0`             | Version of `lsb-release` package used to install components.     |
-| GNUPG_VERSION          | `2.2.27-2+deb11u2`   | Version of `gnupg` package used to install components.           |
-
 [Azure Pipelines container jobs]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases


### PR DESCRIPTION
Remove dependencies only required for building the image from final image

Fixes #80 