### PR TITLE
Reenable Repology updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:11.6-slim AS base
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-#Disabled renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
+# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
 ENV CACERTIFICATES_VERSION=20210119
 
 RUN apt-get update -y && \
@@ -21,11 +21,11 @@ FROM base AS build
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-#Disabled renovate: datasource=repology depName=debian_11/curl versioning=loose
+# renovate: datasource=repology depName=debian_11/curl versioning=loose
 ENV CURL_VERSION=7.74.0-1.3+deb11u5
-#Disabled renovate: datasource=repology depName=debian_11/lsb-release versioning=loose
+# renovate: datasource=repology depName=debian_11/lsb-release versioning=loose
 ENV LSBRELEASE_VERSION=11.1.0
-#Disabled renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
+# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
 ENV GNUPG_VERSION=2.2.27-2+deb11u2
 
 RUN apt-get update -y && \


### PR DESCRIPTION
Reenable update checks from Repology GitHub app should no longer be banned.

See https://github.com/renovatebot/renovate/discussions/20152 for details.