### PR TITLE
Use latest version of workflows

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   lint-image:
     name: Lint Code Base
-    uses: swissgrc/.github/.github/workflows/lint-image.yml@64300ea603ac439c79d240c6cc89cd9f0268dcbb
+    uses: swissgrc/.github/.github/workflows/lint-image.yml@main
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish-image:
     name: Build and push Docker image
-    uses: swissgrc/.github/.github/workflows/publish-image.yml@64300ea603ac439c79d240c6cc89cd9f0268dcbb
+    uses: swissgrc/.github/.github/workflows/publish-image.yml@main
     with:
       image-name: swissgrc/azure-pipelines-dotnet
     secrets:


### PR DESCRIPTION
Renovate can't update to latest SHA without source repository being tagged. It's therefore better to use latest version of workflows. Individual actions in the workflow are still pinned and managed by Renovated.