### PR TITLE
Disable .NET SDK major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>swissgrc/renovate-presets:docker"
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": [ "dotnet/sdk" ],
+      "description": "No .NET SDK Major Updates",      
+      "extends": [ ":disableMajorUpdates" ]
+    }
   ]
 }


### PR DESCRIPTION
Since we decided to create a [dedicated repository](https://github.com/swissgrc/docker-azure-pipelines-dotnet-7) for .NET 7 images, .NET SDK major updates should be disabled in renovate.